### PR TITLE
Added self-message feature

### DIFF
--- a/chatopia/app/api/request/route.ts
+++ b/chatopia/app/api/request/route.ts
@@ -12,9 +12,17 @@ export async function POST(request: Request) {
             return new NextResponse('Unauthorized', { status: 401 });
         }
 
-        // User cannot add themselves as a contact
+        // User can add themselves as a contact
         if (currentUser.email === email) {
-            return new NextResponse('Cannot add yourself as a contact', { status: 400 });
+            await prisma.request.create({
+                data: {
+                    senderId: currentUser.id,
+                    recverId: currentUser.id,
+                    status: 'accepted'
+                }
+            });
+            
+            return new NextResponse('Success', { status: 200 });
         }
 
         // Obtain the user to be added as a contact

--- a/chatopia/app/conversations/[conversationId]/components/Header.tsx
+++ b/chatopia/app/conversations/[conversationId]/components/Header.tsx
@@ -57,6 +57,7 @@ const Header: React.FC<HeaderProps> = ({conversation}) => {
               <div className={styles.textContainer}>
                 <div>
                   {conversation.name || otherUser.name}
+                  {conversation.isSelf && " (You)"}
                 </div>
                 <div className={styles.status}>
                   {statusText}

--- a/chatopia/app/conversations/components/ConversationBox.tsx
+++ b/chatopia/app/conversations/components/ConversationBox.tsx
@@ -89,7 +89,7 @@ const ConversationBox: React.FC<ConversationBoxProps> = ({
       console.log("active list:" , activeList);
       // const activeEmails = activeList.map((activeUser)=>activeUser.email );
       // console.log("active emails:" , activeEmails);
-      const isActive = activeList.includes(otherUser.email);
+      const isActive = activeList.includes(otherUser.email!);
 
     return (
         <div 
@@ -111,6 +111,7 @@ const ConversationBox: React.FC<ConversationBoxProps> = ({
                 <div className={styles.conversation}>
                   <p className={styles.name}>
                     {data.name || otherUser.name}
+                    {data.isSelf && " (You)"}
                   </p>
                   {lastMessage?.createdAt && (
                     <p className={styles.dateTime}>

--- a/chatopia/app/hooks/useOtherUser.ts
+++ b/chatopia/app/hooks/useOtherUser.ts
@@ -3,16 +3,14 @@ import { useMemo } from "react";
 import { FullConversationType , userConversation } from "../types";
 // import { UserConversation } from "@prisma/client";
 
-const useOtherUser = (conversation: 
-    FullConversationType | {userConversations : userConversation[]}
-) => {
+const useOtherUser = (conversation: FullConversationType) => {
     const session = useSession();
     const users = conversation.userConversations.map((userConversation) => userConversation.user);
     
-    
     const otherUser = useMemo(() => {
         const currentUserEmail = session?.data?.user?.email;
-        const otherUser = users.filter((user) => user.email !== currentUserEmail);
+
+        const otherUser = users.filter((user) => conversation.isSelf || user.email !== currentUserEmail);
         return otherUser[0];
     }, [session?.data?.user?.email, users]);
 

--- a/chatopia/app/users/components/UserBox.tsx
+++ b/chatopia/app/users/components/UserBox.tsx
@@ -11,10 +11,11 @@ import LoadingModal from "@/app/components/LoadingModal";
 import {socket} from "@/socket";
 
 interface UserBoxProps {
-    data: User
+    data: User,
+    isSelf: boolean
 }
 
-const UserBox: React.FC<UserBoxProps> = ({data}) => {
+const UserBox: React.FC<UserBoxProps> = ({data, isSelf}) => {
     const router = useRouter();
     const [isLoading, setIsLoading] = useState(false);
 
@@ -23,7 +24,8 @@ const UserBox: React.FC<UserBoxProps> = ({data}) => {
         setIsLoading(true);
     
         axios.post('/api/conversations', { 
-          userId: data.id
+          userId: data.id,
+          isSelf
         })
         .then((res) => {
           if(res.data.type === 'new'){
@@ -45,6 +47,7 @@ const UserBox: React.FC<UserBoxProps> = ({data}) => {
               <div>
                 <p>
                   {data.name}
+                  {isSelf && " (You)"}
                 </p>
               </div>
             </div>

--- a/chatopia/app/users/components/UserList.tsx
+++ b/chatopia/app/users/components/UserList.tsx
@@ -10,10 +10,11 @@ import GroupChatModal from "./ContactModal";
 import ContactModal from "./ContactModal";
 
 interface UserListProps {
-  items: User[]
+  items: User[],
+  currentUserId: string
 };
 
-const UserList: React.FC<UserListProps> = ({items}) => {
+const UserList: React.FC<UserListProps> = ({items, currentUserId}) => {
     const {isDark ,setIsDark} = useContext(ThemeContext);
     const [isModalOpen, setIsModalOpen] = useState(false);
   
@@ -35,7 +36,7 @@ const UserList: React.FC<UserListProps> = ({items}) => {
                 </div>
             </div>
                 {items.map((item) => (
-                    <UserBox key={item.id} data={item}/>
+                    <UserBox isSelf={currentUserId === item.id} key={item.id} data={item}/>
                 ))}
             
         </aside>

--- a/chatopia/app/users/layout.tsx
+++ b/chatopia/app/users/layout.tsx
@@ -37,7 +37,7 @@ export default async function UsersLayout({
   return (
       <Sidebar>
         <div style={{height:"100vh" , display:"flex"}}>
-          <UserList items={contacts} />
+          <UserList currentUserId={currentUser.id} items={contacts} />
           {children}
           <RequestList sentUsers={sentUsers} recvdUsers={receivedUsers}/>
         </div>

--- a/chatopia/prisma/schema.prisma
+++ b/chatopia/prisma/schema.prisma
@@ -51,6 +51,7 @@ model Conversation {
   lastMessageAt DateTime @default(now())
   name String?
   isGroup Boolean?
+  isSelf Boolean?
   image String?
 
   messages Message[]


### PR DESCRIPTION
Added an `isSelf` property in the conversations postgres table.

### Previous flow:
Add contact
-> If `currentUser.email` is equivalent to `contactUser.email` -> throw error
-> else create Request with pending status

### Current flow:
Current flow will create Request with accepted status if the emails are equivalent.

#### Others: 
Conversation is created with isSelf property set to true when the `UserBox` component is clicked in the `/users` page

Label ` (You)` is shown in the `/users` UserBox and `/conversations` MessageBox component. These client side components get the isSelf data as prop from respective parent components.