### PR TITLE
Prevent duplicate friend requests

### DIFF
--- a/chatopia/app/api/request/route.ts
+++ b/chatopia/app/api/request/route.ts
@@ -37,6 +37,17 @@ export async function POST(request: Request) {
             return new NextResponse('User not found', { status: 404 });
         }
 
+        const reqFromReciever = await prisma.request.findFirst({
+            where: {
+                senderId: receiver.id,
+                recverId: currentUser.id
+            }
+        });
+
+        if (reqFromReciever) {
+            return new NextResponse(`Request from ${receiver.email} exists.`, { status: 400 })
+        }
+
         // Add the contact
         await prisma.request.create({
             data: {
@@ -50,6 +61,9 @@ export async function POST(request: Request) {
         return new NextResponse('Success', { status: 200 });
 
     } catch (error: any) {
+      if (error.code === 'P2002') {
+        return new NextResponse('Request already exists', { status: 400 });
+      }
       console.log(error, 'ERROR_MESSAGES');
       return new NextResponse('InternalError', { status: 500 });
     }

--- a/chatopia/app/users/components/ContactModal.tsx
+++ b/chatopia/app/users/components/ContactModal.tsx
@@ -10,6 +10,7 @@ import {
     SubmitHandler, 
     useForm
   } from "react-hook-form";
+import toast from "react-hot-toast";
 
 
 interface ContactModalProps {
@@ -37,6 +38,7 @@ const ContactModal: React.FC<ContactModalProps> = ({ isOpen, onClose }) => {
     const onSubmit: SubmitHandler<FieldValues> = (data) => {
         setValue('email', '');
         axios.post('/api/request', data)
+        .catch(e => toast.error(e.response.data || "Something went wrong!"));
     };
 
     return (


### PR DESCRIPTION
In the `/api/request` api route, additional database select query is called to check if an request exists already and toast library is used to show the error at the frontend.